### PR TITLE
Use json-fn to support es6

### DIFF
--- a/lib/finalizer.js
+++ b/lib/finalizer.js
@@ -4,6 +4,7 @@ var fs = require("fs"),
 
 function readPath(options, path, size) {
   var text = null;
+
   if (options.onFilepathSearchFn && (text = options.onFilepathSearchFn(path)))
     return text;
 

--- a/lib/nak.js
+++ b/lib/nak.js
@@ -1,3 +1,5 @@
+const {serialize,deserialize} = require("./serialise-fn")
+
 // used when nak is run from a script
 exports.run = function(options) {
   if (!options) {
@@ -172,12 +174,5 @@ function makeQuery(query, replacement) {
 
 }
 
-var simplefunc = require("simplefunc");
-
-exports.serialize = function(fn) {
-  return simplefunc.toJson(fn);
-};
-
-exports.deserialize = function(fn) {
-  return simplefunc.fromJson(fn);
-};
+exports.deserialize = deserialize;
+exports.serialize = serialize;

--- a/lib/options.js
+++ b/lib/options.js
@@ -35,9 +35,9 @@
 
 var path = require("path");
 var parser = {};
+var {deserialize} = require("./serialise-fn");
 module.exports = parser;
 
-var simplefunc = require('simplefunc'),
 // Option definitions.
 schema = [
     ['l', 'list',             '', '                list files encountered'],
@@ -116,7 +116,7 @@ parseArgs = parser.parseArgs = function(passedArgs) {
 
     // turn string functions into real functions
     if (process.env.nak_onFilepathSearchFn) {
-      options.onFilepathSearchFn = simplefunc.fromJson(process.env.nak_onFilepathSearchFn);
+      options.onFilepathSearchFn = deserialize(process.env.nak_onFilepathSearchFn);
     }
     else if (options.onFilepathSearchFn) {
       options.onFilepathSearchFn = new Function("filepath", options.onFilepathSearchFn);

--- a/lib/serialise-fn.js
+++ b/lib/serialise-fn.js
@@ -1,0 +1,9 @@
+var JSONfn = require("json-fn");
+
+exports.serialize = function(fn) {
+    return JSONfn.stringify(fn).replace(/ +/g, " ");
+};
+
+exports.deserialize = function(fn) {
+    return JSONfn.parse(fn);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -392,6 +392,11 @@
                 "argparse": "^2.0.1"
             }
         },
+        "json-fn": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/json-fn/-/json-fn-1.1.1.tgz",
+            "integrity": "sha1-QpPJGYpILWaX0zSm4yzQ0iESHoA="
+        },
         "locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -562,11 +567,6 @@
             "requires": {
                 "randombytes": "^2.1.0"
             }
-        },
-        "simplefunc": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/simplefunc/-/simplefunc-0.0.2.tgz",
-            "integrity": "sha1-cAybtS1lIerernLZgW1UQqoy6O8="
         },
         "source-map": {
             "version": "0.1.43",

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
         }
     ],
     "dependencies": {
+        "json-fn": "^1.1.1",
         "isbinaryfile": "2.0.0",
-        "simplefunc": "0.0.2",
         "colors": "0.6.2"
     },
     "devDependencies": {
         "mocha": "^9.2.1",
-        "wrench": "1.5.1",
-        "uglify-js": "2.3.5"
+        "uglify-js": "2.3.5",
+        "wrench": "1.5.1"
     },
     "bin": {
         "nak": "./bin/nak"

--- a/tests/search_test.js
+++ b/tests/search_test.js
@@ -221,5 +221,22 @@ describe("search", function() {
           next();
          });
       });
+
+      it("should understand what to do with onFilepathSearchFn (es6 arrow function)", function(next) {
+         var fn = (filepath) => {
+          if (/file1\.txt/.test(filepath)) return "photo";
+          return null;
+         };
+
+         process.env.nak_onFilepathSearchFn = nak.serialize(fn);
+
+         Exec(nakPath + " -a .nakignore 'photo' " + basePath, function(err, stdout, stderr) {
+          var output = parseOutput(err, stdout, stderr);
+
+          Assert.equal(output.count, 5);
+          Assert.equal(output.filecount, 3);
+          next();
+         });
+      });
     });
 });


### PR DESCRIPTION
The library `simplefunc` has ambiguous licensing and doesn't support es6 arrow functions.

Switch to https://github.com/vkiryukhin/jsonfn

Although the repo is inactive, the lib is fairly popular on npm and the code looks robust.
Most importantly, licensing and support for es6 functions.